### PR TITLE
Adding default security group ID to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,5 +232,6 @@ include {
 | <a name="output_aws_subnet_private_ids"></a> [aws\_subnet\_private\_ids](#output\_aws\_subnet\_private\_ids) | private.tf |
 | <a name="output_aws_subnet_public"></a> [aws\_subnet\_public](#output\_aws\_subnet\_public) | n/a |
 | <a name="output_aws_subnet_public_ids"></a> [aws\_subnet\_public\_ids](#output\_aws\_subnet\_public\_ids) | public.tf |
+| <a name="output_default_security_group_id"></a> [default\_security\_group\_id](#output\_default\_security\_group\_id) | n/a |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | Full VPC submodule output |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,3 +84,7 @@ output "aws_route_table_association_firewall" {
 output "aws_firewall_route_table_ids" {
   value = [for k, v in aws_route_table.firewall : v.id]
 }
+
+output "default_security_group_id" {
+  value = aws_default_security_group.this.id
+}


### PR DESCRIPTION
## what
This pull request includes a small change to the `outputs.tf` file. The change adds a new output for the default security group ID.

* [`outputs.tf`](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R87-R90): Added a new output `default_security_group_id` to provide the ID of the default security group.
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
